### PR TITLE
[CI] Update e2e-test.yaml

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,10 +1,16 @@
 name: E2E Test
 on:
   pull_request:
-    types: 
+    types:
       - opened
       - synchronize
       - edited
+  workflow_dispatch:
+    inputs:
+      helm_chart_version:
+        description: 'Meshery Helm Chart Version'
+        required: false
+        default: 'v0.8.58' # Default value for the Helm chart version
 
 jobs:
   e2e-test:
@@ -21,14 +27,14 @@ jobs:
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
           helm version
       - name: Build and Install Plugin
-        run: | 
+        run: |
           ./scripts/e2e.sh
         env:
           PROVIDER_TOKEN: ${{ secrets.PROVIDER_TOKEN }}
-          WORKFLOW_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}          
+          WORKFLOW_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Snapshot Meshery Helm Chart
         run: |
           helm plugin list
-          helm helm-kanvas-snapshot -f https://meshery.io/charts/meshery-v0.8.12.tgz --name meshery-chart
-
-      
+          # Use the input variable with a fallback to the default value
+          HELM_CHART_VERSION=${{ github.event.inputs.helm_chart_version || 'v0.8.58' }}
+          helm helm-kanvas-snapshot -f https://meshery.io/charts/meshery-${HELM_CHART_VERSION}.tgz --name meshery-chart


### PR DESCRIPTION
**Notes for Reviewers**

This PR adds:

1. manual workflow dispatch with optional input for helm chart version
2. externalizes helm chart value (for manually dispatched workflows) with default helm chart version.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
