### PR TITLE
ci: update goreleaser github token

### DIFF
--- a/.github/workflows/build-and-release-snapshot-plugin.yml
+++ b/.github/workflows/build-and-release-snapshot-plugin.yml
@@ -43,6 +43,6 @@ jobs:
         env:
           RELEASE_CHANNEL: "stable"
           PROVIDER_TOKEN: ${{ secrets.PROVIDER_TOKEN }}
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #127 

- Map `GITHUB_TOKEN` to `GH_ACCESS_TOKEN` in CI workflow

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
