### PR TITLE
chore: remove codecov integration

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -51,12 +51,7 @@ jobs:
           go-version: "1.23"
       - name: Run coverage
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
-      - name: Upload coverage to Codecov
-        if: github.repository == 'meshery-extensions/helm-kanvas-snapshot'
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.txt
-          flags: unittests
+      
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-24.04
@@ -83,11 +78,4 @@ jobs:
         run:
           # TODO: add tests for snapshot
           echo "Running kanvas snapshot test completed."
-
-      - name: Upload coverage to Codecov
-        if: github.repository == 'meshery-extensions/helm-kanvas-snapshot'
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.txt
-          flags: gointegrationtests
 


### PR DESCRIPTION
**Changes I Made**
- **Removed** Codecov upload steps from `.github/workflows/go-testing-ci.yml`:
  - Unit tests codecov upload
  - Integration tests codecov upload
- **Retained** coverage generation step for local development:
  - `go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic` (unit tests)

**Impact**
- Tests continue to run with coverage generation
- Coverage reports remain available locally for developers
- Codecov uploads and external reporting removed

**Related**
Part of organization-wide effort to remove Codecov integration across Meshery and Meshery Extensions repositories.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
