### PR TITLE
chore: bump Go version to 1.26.4

### DIFF
--- a/.github/workflows/build-and-release-snapshot-plugin.yml
+++ b/.github/workflows/build-and-release-snapshot-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: Install Helm
         run: |
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Build Error Utility
         run: |

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -21,7 +21,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [1.23]
+        go: [1.26.4]
         os: [ubuntu-24.04]
     name: golangci-lint
     if: github.repository == 'meshery-extensions/helm-kanvas-snapshot'
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: Run coverage
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: Install Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: Setup Cache
         uses: actions/cache@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery-extensions/helm-kanvas-snapshot
 
-go 1.23.4
+go 1.26.4
 
 require (
 	github.com/layer5io/meshkit v0.8.29

--- a/helpers/Makefile.core.mk
+++ b/helpers/Makefile.core.mk
@@ -1,4 +1,4 @@
-GOVERSION = 1.21
+GOVERSION = 1.26.4
 PROVIDER_TOKEN="dev_token"
 MESHERY_CLOUD_API_BASE_URL="https://cloud.layer5.io"
 MESHERY_API_BASE_URL="https://playground.meshery.io"


### PR DESCRIPTION
**Description**

Upgrade Go version from 1.23 to 1.26.4.

**Fixes:** meshery/meshery#19875

**Verified with:**

- `go build ./...`
- `go test ./...`
- `go vet ./...`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 